### PR TITLE
fix: res.sendFile absolute path error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ import http from 'http';
 import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import path from 'path';
 import routes from './routers';
 
 const app = express();
@@ -15,7 +16,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use('/api', cors(), routes);
 app.use('/', express.static('fe'));
-app.use((req, res) => res.sendFile('./fe/index.html'));
+app.use((req, res) => res.sendFile(path.resolve('fe/index.html')));
 
 const server = http.createServer(app);
 


### PR DESCRIPTION
重现步骤：本地执行 `npm run dev`，浏览器打开`http://localhost:7749/`，nodejs 控制台有错误提示：
```
TypeError: path must be absolute or specify root to res.sendFile
    at ServerResponse.sendFile (/Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/response.js:425:11)
    at file:///Users/shuchen/study/web-components/mt-music-player/server/index.js:18:27
    at Layer.handle [as handle_request] (/Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/router/index.js:317:13)
    at /Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/router/index.js:335:12)
    at next (/Users/shuchen/study/web-components/mt-music-player/node_modules/express/lib/router/index.js:275:10)
    at SendStream.error (/Users/shuchen/study/web-components/mt-music-player/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (events.js:200:13)
    at SendStream.error (/Users/shuchen/study/web-components/mt-music-player/node_modules/send/index.js:270:17)
    at SendStream.onStatError (/Users/shuchen/study/web-components/mt-music-player/node_modules/send/index.js:421:12)
    at onstat (/Users/shuchen/study/web-components/mt-music-player/node_modules/send/index.js:726:26)
    at FSReqCallback.oncomplete (fs.js:165:21)
```

执行环境
```
System:
    OS: macOS 10.14
    CPU: (4) x64 Intel(R) Core(TM) i5-5575R CPU @ 2.80GHz
    Memory: 71.42 MB / 8.00 GB
    Shell: 5.3 - /bin/zsh
Binaries:
    Node: 12.4.0 - /usr/local/bin/node
    Yarn: 1.5.1 - /usr/local/bin/yarn
    npm: 6.9.0 - /usr/local/bin/npm
    Watchman: 4.9.0 - /usr/local/bin/watchman
```